### PR TITLE
feat(S1T6): implement location permission service with interface and …

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:label="animal_map"
         android:name="${applicationName}"

--- a/lib/services/location_permission_service.dart
+++ b/lib/services/location_permission_service.dart
@@ -1,0 +1,20 @@
+import 'package:permission_handler/permission_handler.dart';
+
+/// Abstract interface for location permission operations.
+///
+/// Enables dependency inversion so that callers depend on an abstraction
+/// rather than a concrete permission library. This makes the service
+/// injectable and mockable in tests.
+abstract class LocationPermissionService {
+  /// Checks whether location permission is currently granted.
+  Future<bool> isGranted();
+
+  /// Requests location permission from the user.
+  ///
+  /// Returns `true` if permission was granted (or was already granted),
+  /// `false` otherwise.
+  Future<bool> request();
+
+  /// Returns the current [PermissionStatus] for location.
+  Future<PermissionStatus> status();
+}

--- a/lib/services/location_permission_service_impl.dart
+++ b/lib/services/location_permission_service_impl.dart
@@ -1,0 +1,27 @@
+import 'package:permission_handler/permission_handler.dart';
+
+import 'location_permission_service.dart';
+
+/// Concrete implementation of [LocationPermissionService] using
+/// the `permission_handler` package.
+///
+/// This is the production implementation that interacts with the
+/// real Android/iOS permission system.
+class LocationPermissionServiceImpl implements LocationPermissionService {
+  @override
+  Future<bool> isGranted() async {
+    final currentStatus = await Permission.location.status;
+    return currentStatus.isGranted;
+  }
+
+  @override
+  Future<bool> request() async {
+    final currentStatus = await Permission.location.request();
+    return currentStatus.isGranted;
+  }
+
+  @override
+  Future<PermissionStatus> status() {
+    return Permission.location.status;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -216,6 +216,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_maps_flutter: ^2.14.2
+  permission_handler: ^12.0.1
 
 dev_dependencies:
   flutter_test:

--- a/test/fakes/fake_location_permission_service.dart
+++ b/test/fakes/fake_location_permission_service.dart
@@ -1,0 +1,38 @@
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:animal_map/services/location_permission_service.dart';
+
+/// A fake implementation of [LocationPermissionService] for testing.
+///
+/// Allows tests to control permission state without touching the
+/// real Android/iOS permission system.
+class FakeLocationPermissionService implements LocationPermissionService {
+  PermissionStatus _status;
+
+  FakeLocationPermissionService({
+    PermissionStatus initialStatus = PermissionStatus.denied,
+  }) : _status = initialStatus;
+
+  /// The status that [request] will transition to when called.
+  PermissionStatus statusAfterRequest = PermissionStatus.granted;
+
+  /// How many times [request] has been called.
+  int requestCallCount = 0;
+
+  @override
+  Future<bool> isGranted() async {
+    return _status.isGranted;
+  }
+
+  @override
+  Future<bool> request() async {
+    requestCallCount++;
+    _status = statusAfterRequest;
+    return _status.isGranted;
+  }
+
+  @override
+  Future<PermissionStatus> status() async {
+    return _status;
+  }
+}

--- a/test/services/location_permission_service_test.dart
+++ b/test/services/location_permission_service_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../fakes/fake_location_permission_service.dart';
+
+void main() {
+  group('LocationPermissionService (via Fake)', () {
+    late FakeLocationPermissionService service;
+
+    setUp(() {
+      service = FakeLocationPermissionService();
+    });
+
+    test('isGranted returns false when permission is denied', () async {
+      expect(await service.isGranted(), isFalse);
+    });
+
+    test('isGranted returns true when permission is granted', () async {
+      service = FakeLocationPermissionService(
+        initialStatus: PermissionStatus.granted,
+      );
+
+      expect(await service.isGranted(), isTrue);
+    });
+
+    test('status returns the current permission status', () async {
+      expect(await service.status(), PermissionStatus.denied);
+
+      service = FakeLocationPermissionService(
+        initialStatus: PermissionStatus.permanentlyDenied,
+      );
+      expect(await service.status(), PermissionStatus.permanentlyDenied);
+    });
+
+    test('request transitions to granted and returns true', () async {
+      expect(await service.isGranted(), isFalse);
+
+      final result = await service.request();
+
+      expect(result, isTrue);
+      expect(await service.isGranted(), isTrue);
+      expect(service.requestCallCount, 1);
+    });
+
+    test('request transitions to denied when configured', () async {
+      service.statusAfterRequest = PermissionStatus.denied;
+
+      final result = await service.request();
+
+      expect(result, isFalse);
+      expect(await service.isGranted(), isFalse);
+      expect(service.requestCallCount, 1);
+    });
+
+    test('request transitions to permanentlyDenied when configured', () async {
+      service.statusAfterRequest = PermissionStatus.permanentlyDenied;
+
+      final result = await service.request();
+
+      expect(result, isFalse);
+      expect(await service.status(), PermissionStatus.permanentlyDenied);
+    });
+
+    test('multiple requests increment call count', () async {
+      await service.request();
+      await service.request();
+      await service.request();
+
+      expect(service.requestCallCount, 3);
+    });
+
+    test('request does not change status if already granted', () async {
+      service = FakeLocationPermissionService(
+        initialStatus: PermissionStatus.granted,
+      );
+
+      final result = await service.request();
+
+      expect(result, isTrue);
+      expect(await service.isGranted(), isTrue);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION

Infrastructure:
- Added permission_handler ^12.0.1 dependency
- Added ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION to AndroidManifest.xml

Architecture (DIP / OCP):
- lib/services/location_permission_service.dart: abstract interface
- lib/services/location_permission_service_impl.dart: concrete implementation
- test/fakes/fake_location_permission_service.dart: configurable fake for tests

Tests:
- test/services/location_permission_service_test.dart: 8 unit tests covering granted, denied, permanentlyDenied, request transitions, and call count tracking

All 24 tests passing

Closes #7 