### PR TITLE
feat(S1T7): enable my-location layer when permission granted

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,12 +1,22 @@
 import 'package:flutter/material.dart';
 
 import 'screens/map/map_screen.dart';
+import 'services/location_permission_service.dart';
+import 'services/location_permission_service_impl.dart';
 
 /// Root application widget.
 ///
-/// Configures theming and sets [MapScreen] as the home screen.
+/// Configures theming and provides production dependencies
+/// to child screens.
 class AnimalMapApp extends StatelessWidget {
-  const AnimalMapApp({super.key});
+  /// Creates the app with an optional [LocationPermissionService] override.
+  ///
+  /// Defaults to [LocationPermissionServiceImpl] for production.
+  /// Pass a fake/mock for testing.
+  const AnimalMapApp({super.key, LocationPermissionService? locationPermissionService})
+      : _locationPermissionService = locationPermissionService;
+
+  final LocationPermissionService? _locationPermissionService;
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +25,10 @@ class AnimalMapApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.cyan),
       ),
-      home: const MapScreen(),
+      home: MapScreen(
+        locationPermissionService:
+            _locationPermissionService ?? LocationPermissionServiceImpl(),
+      ),
     );
   }
 }

--- a/lib/screens/map/map_screen.dart
+++ b/lib/screens/map/map_screen.dart
@@ -2,13 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../../config/map_config.dart';
+import '../../services/location_permission_service.dart';
 
 /// Main screen that displays the Google Map.
 ///
-/// Responsible only for rendering the map widget and managing the
-/// [GoogleMapController]. All configuration is delegated to [MapConfig].
+/// Accepts a [LocationPermissionService] via constructor injection
+/// to enable dependency inversion and testability.
+/// Requests location permission on initialization and enables
+/// the "my location" layer when granted.
 class MapScreen extends StatefulWidget {
-  const MapScreen({super.key});
+  const MapScreen({super.key, required this.locationPermissionService});
+
+  /// Injected permission service (interface, not concrete).
+  final LocationPermissionService locationPermissionService;
 
   @override
   State<MapScreen> createState() => _MapScreenState();
@@ -16,6 +22,20 @@ class MapScreen extends StatefulWidget {
 
 class _MapScreenState extends State<MapScreen> {
   GoogleMapController? _mapController;
+  bool _myLocationEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _requestLocationPermission();
+  }
+
+  Future<void> _requestLocationPermission() async {
+    final granted = await widget.locationPermissionService.request();
+    setState(() {
+      _myLocationEnabled = granted;
+    });
+  }
 
   void _onMapCreated(GoogleMapController controller) {
     _mapController = controller;
@@ -47,8 +67,8 @@ class _MapScreenState extends State<MapScreen> {
         rotateGesturesEnabled: true,
         tiltGesturesEnabled: true,
         mapType: MapType.normal,
-        myLocationEnabled: false,
-        myLocationButtonEnabled: false,
+        myLocationEnabled: _myLocationEnabled,
+        myLocationButtonEnabled: _myLocationEnabled,
       ),
     );
   }

--- a/test/screens/map/map_screen_test.dart
+++ b/test/screens/map/map_screen_test.dart
@@ -1,23 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'package:animal_map/config/map_config.dart';
 import 'package:animal_map/screens/map/map_screen.dart';
 
+import '../../fakes/fake_location_permission_service.dart';
+
 void main() {
   group('MapScreen', () {
+    late FakeLocationPermissionService fakePermissionService;
+
+    setUp(() {
+      fakePermissionService = FakeLocationPermissionService();
+    });
+
+    Widget buildSubject() {
+      return MaterialApp(
+        home: MapScreen(
+          locationPermissionService: fakePermissionService,
+        ),
+      );
+    }
+
     testWidgets('renders a Scaffold with AppBar titled "Animal Map"', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       expect(find.byType(Scaffold), findsOneWidget);
       expect(find.text('Animal Map'), findsOneWidget);
     });
 
     testWidgets('contains a GoogleMap widget', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       expect(find.byType(GoogleMap), findsOneWidget);
     });
@@ -25,7 +44,8 @@ void main() {
     testWidgets('GoogleMap uses MapConfig initial camera position', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
@@ -42,7 +62,8 @@ void main() {
     testWidgets('GoogleMap has zoom gestures enabled', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
@@ -53,7 +74,8 @@ void main() {
     testWidgets('GoogleMap has min/max zoom set from MapConfig', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
@@ -61,15 +83,41 @@ void main() {
       expect(googleMap.minMaxZoomPreference.maxZoom, MapConfig.maxZoom);
     });
 
-    testWidgets('myLocation is disabled by default', (
+    testWidgets('myLocation is disabled when permission denied', (
       WidgetTester tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: MapScreen()));
+      fakePermissionService.statusAfterRequest = PermissionStatus.denied;
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
       final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
       expect(googleMap.myLocationEnabled, isFalse);
       expect(googleMap.myLocationButtonEnabled, isFalse);
+    });
+
+    testWidgets('myLocation is enabled when permission granted', (
+      WidgetTester tester,
+    ) async {
+      fakePermissionService.statusAfterRequest = PermissionStatus.granted;
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
+
+      expect(googleMap.myLocationEnabled, isTrue);
+      expect(googleMap.myLocationButtonEnabled, isTrue);
+    });
+
+    testWidgets('requests permission exactly once on init', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(fakePermissionService.requestCallCount, 1);
     });
   });
 }

--- a/test/stories/story1/map_renders_test.dart
+++ b/test/stories/story1/map_renders_test.dart
@@ -1,12 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 import 'package:animal_map/app.dart';
 import 'package:animal_map/config/map_config.dart';
 
+import '../../fakes/fake_location_permission_service.dart';
+
 /// BDD scenarios for Story 1: Map renders in the app
 void main() {
   group('Story 1 — Map renders in the app', () {
+    late FakeLocationPermissionService fakePermissionService;
+
+    setUp(() {
+      fakePermissionService = FakeLocationPermissionService();
+    });
+
     // Scenario: App launches and map renders
     // Given the app is installed and a valid Google Maps API key is configured
     // When I open the app
@@ -15,7 +24,10 @@ void main() {
     testWidgets(
       'Scenario: App launches and map renders with pan and zoom',
       (WidgetTester tester) async {
-        await tester.pumpWidget(const AnimalMapApp());
+        await tester.pumpWidget(AnimalMapApp(
+          locationPermissionService: fakePermissionService,
+        ));
+        await tester.pumpAndSettle();
 
         // Then a Google Map is displayed
         expect(find.byType(GoogleMap), findsOneWidget);
@@ -37,7 +49,12 @@ void main() {
     testWidgets(
       'Scenario: Default camera position when location not granted',
       (WidgetTester tester) async {
-        await tester.pumpWidget(const AnimalMapApp());
+        fakePermissionService.statusAfterRequest = PermissionStatus.denied;
+
+        await tester.pumpWidget(AnimalMapApp(
+          locationPermissionService: fakePermissionService,
+        ));
+        await tester.pumpAndSettle();
 
         final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
@@ -62,12 +79,38 @@ void main() {
     testWidgets(
       'Scenario: Location layer disabled when permission not granted',
       (WidgetTester tester) async {
-        await tester.pumpWidget(const AnimalMapApp());
+        fakePermissionService.statusAfterRequest = PermissionStatus.denied;
+
+        await tester.pumpWidget(AnimalMapApp(
+          locationPermissionService: fakePermissionService,
+        ));
+        await tester.pumpAndSettle();
 
         final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
 
         expect(googleMap.myLocationEnabled, isFalse);
         expect(googleMap.myLocationButtonEnabled, isFalse);
+      },
+    );
+
+    // Scenario: Location layer enabled
+    // Given location permission is granted
+    // When the app loads the map
+    // Then the "my location" indicator is shown
+    testWidgets(
+      'Scenario: Location layer enabled when permission granted',
+      (WidgetTester tester) async {
+        fakePermissionService.statusAfterRequest = PermissionStatus.granted;
+
+        await tester.pumpWidget(AnimalMapApp(
+          locationPermissionService: fakePermissionService,
+        ));
+        await tester.pumpAndSettle();
+
+        final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
+
+        expect(googleMap.myLocationEnabled, isTrue);
+        expect(googleMap.myLocationButtonEnabled, isTrue);
       },
     );
   });


### PR DESCRIPTION
Architecture:
- MapScreen now accepts LocationPermissionService via constructor (DIP)
- Requests permission on initState, toggles myLocationEnabled/myLocationButtonEnabled
- AnimalMapApp accepts optional LocationPermissionService override for testing, defaults to LocationPermissionServiceImpl in production

Tests updated:
- map_screen_test.dart: 8 tests (added permission-granted, permission-denied, and request-call-count tests using FakeLocationPermissionService)
- map_renders_test.dart: 4 BDD scenarios (added 'Location layer enabled when permission granted' scenario)

All 27 tests passing

Closes #8 